### PR TITLE
add uninstall to installpath

### DIFF
--- a/install_zerotier_gaming_fix.bat
+++ b/install_zerotier_gaming_fix.bat
@@ -66,6 +66,7 @@ echo ==============================================================
 echo.
 echo.
 xcopy "%SOURCE_DIR%\*" "%TARGET_DIR%" /Y /E
+xcopy "%SOURCE_DIR%\..\uninstall_zerotier_gaming_fix.bat" "%TARGET_DIR%" /Y
 
 
 echo.


### PR DESCRIPTION
Before this version, people needed to find the uninstall.bat file in another directory
so I think we need add uninstallbat to installpath